### PR TITLE
Added tests and hound DNA mapping

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,12 +19,12 @@
   "plugins": ["react", "@typescript-eslint"],
   "rules": {
     "indent": ["error", 2],
-    "linebreak-style": ["error", "unix"],
+    "linebreak-style": ["error", "windows"],
     "quotes": ["error", "double"],
     "semi": ["error", "always"],
     "eol-last": ["warn", "always"],
     "arrow-parens": ["warn", "always"],
-    "func-style": ["warn", "declaration"],
+    "func-style": ["ignore", "declaration"],
     "@typescript-eslint/no-explicit-any": "off"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,7 @@
   "plugins": ["react", "@typescript-eslint"],
   "rules": {
     "indent": ["error", 2],
-    "linebreak-style": ["error", "windows"],
+    "linebreak-style": ["off", "windows"],
     "quotes": ["error", "double"],
     "semi": ["error", "always"],
     "eol-last": ["warn", "always"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,7 @@
     "semi": ["error", "always"],
     "eol-last": ["warn", "always"],
     "arrow-parens": ["warn", "always"],
-    "func-style": ["ignore", "declaration"],
+    "func-style": ["off", "declaration"],
     "@typescript-eslint/no-explicit-any": "off"
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   Build-and-test:
-    name: Install dependencies and lint project
+    name: Build project and run lints/tests. 
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -18,3 +18,4 @@ jobs:
         node-version: '14'
     - run: npm install --production=false
     - run: npm run lint
+    - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,11 +67,11 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
-			"integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+			"integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
 			"requires": {
-				"@babel/types": "^7.15.0",
+				"@babel/types": "^7.15.4",
 				"jsesc": "^2.5.1",
 				"source-map": "^0.5.0"
 			},
@@ -84,26 +84,26 @@
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.14.5.tgz",
-			"integrity": "sha512-EivH9EgBIb+G8ij1B2jAwSH36WnGvkQSEC6CkX/6v6ZFlw5fVOHvsgGF4uiEHO2GzMvunZb6tDLQEQSdrdocrA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.15.4.tgz",
+			"integrity": "sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==",
 			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.14.5.tgz",
-			"integrity": "sha512-YTA/Twn0vBXDVGJuAX6PwW7x5zQei1luDDo2Pl6q1qZ7hVNl0RZrhHCQG/ArGpR29Vl7ETiB8eJyrvpuRp300w==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.15.4.tgz",
+			"integrity": "sha512-P8o7JP2Mzi0SdC6eWr1zF+AEYvrsZa7GSY1lTayjF5XJhVH0kjLYUZPvTMflP7tBgZoe9gIhTa60QwFpqh/E0Q==",
 			"requires": {
-				"@babel/helper-explode-assignable-expression": "^7.14.5",
-				"@babel/types": "^7.14.5"
+				"@babel/helper-explode-assignable-expression": "^7.15.4",
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
-			"integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
+			"integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
 			"requires": {
 				"@babel/compat-data": "^7.15.0",
 				"@babel/helper-validator-option": "^7.14.5",
@@ -119,16 +119,16 @@
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.15.0.tgz",
-			"integrity": "sha512-MdmDXgvTIi4heDVX/e9EFfeGpugqm9fobBVg/iioE8kueXrOHdRDe36FAY7SnE9xXLVeYCoJR/gdrBEIHRC83Q==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.15.4.tgz",
+			"integrity": "sha512-7ZmzFi+DwJx6A7mHRwbuucEYpyBwmh2Ca0RvI6z2+WLZYCqV0JOaLb+u0zbtmDicebgKBZgqbYfLaKNqSgv5Pw==",
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.14.5",
-				"@babel/helper-function-name": "^7.14.5",
-				"@babel/helper-member-expression-to-functions": "^7.15.0",
-				"@babel/helper-optimise-call-expression": "^7.14.5",
-				"@babel/helper-replace-supers": "^7.15.0",
-				"@babel/helper-split-export-declaration": "^7.14.5"
+				"@babel/helper-annotate-as-pure": "^7.15.4",
+				"@babel/helper-function-name": "^7.15.4",
+				"@babel/helper-member-expression-to-functions": "^7.15.4",
+				"@babel/helper-optimise-call-expression": "^7.15.4",
+				"@babel/helper-replace-supers": "^7.15.4",
+				"@babel/helper-split-export-declaration": "^7.15.4"
 			}
 		},
 		"@babel/helper-create-regexp-features-plugin": {
@@ -163,76 +163,76 @@
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.14.5.tgz",
-			"integrity": "sha512-Htb24gnGJdIGT4vnRKMdoXiOIlqOLmdiUYpAQ0mYfgVT/GDm8GOYhgi4GL+hMKrkiPRohO4ts34ELFsGAPQLDQ==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.15.4.tgz",
+			"integrity": "sha512-J14f/vq8+hdC2KoWLIQSsGrC9EFBKE4NFts8pfMpymfApds+fPqR30AOUWc4tyr56h9l/GA1Sxv2q3dLZWbQ/g==",
 			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-			"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+			"integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.14.5",
-				"@babel/template": "^7.14.5",
-				"@babel/types": "^7.14.5"
+				"@babel/helper-get-function-arity": "^7.15.4",
+				"@babel/template": "^7.15.4",
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-			"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+			"integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
 			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-			"integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+			"integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
 			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
-			"integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+			"integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
 			"requires": {
-				"@babel/types": "^7.15.0"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-			"integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+			"integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
 			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
-			"integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.4.tgz",
+			"integrity": "sha512-9fHHSGE9zTC++KuXLZcB5FKgvlV83Ox+NLUmQTawovwlJ85+QMhk1CnVk406CQVj97LaWod6KVjl2Sfgw9Aktw==",
 			"requires": {
-				"@babel/helper-module-imports": "^7.14.5",
-				"@babel/helper-replace-supers": "^7.15.0",
-				"@babel/helper-simple-access": "^7.14.8",
-				"@babel/helper-split-export-declaration": "^7.14.5",
+				"@babel/helper-module-imports": "^7.15.4",
+				"@babel/helper-replace-supers": "^7.15.4",
+				"@babel/helper-simple-access": "^7.15.4",
+				"@babel/helper-split-export-declaration": "^7.15.4",
 				"@babel/helper-validator-identifier": "^7.14.9",
-				"@babel/template": "^7.14.5",
-				"@babel/traverse": "^7.15.0",
-				"@babel/types": "^7.15.0"
+				"@babel/template": "^7.15.4",
+				"@babel/traverse": "^7.15.4",
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
-			"integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
+			"integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
 			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-plugin-utils": {
@@ -241,48 +241,48 @@
 			"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
 		},
 		"@babel/helper-remap-async-to-generator": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.14.5.tgz",
-			"integrity": "sha512-rLQKdQU+HYlxBwQIj8dk4/0ENOUEhA/Z0l4hN8BexpvmSMN9oA9EagjnhnDpNsRdWCfjwa4mn/HyBXO9yhQP6A==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.15.4.tgz",
+			"integrity": "sha512-v53MxgvMK/HCwckJ1bZrq6dNKlmwlyRNYM6ypaRTdXWGOE2c1/SCa6dL/HimhPulGhZKw9W0QhREM583F/t0vQ==",
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.14.5",
-				"@babel/helper-wrap-function": "^7.14.5",
-				"@babel/types": "^7.14.5"
+				"@babel/helper-annotate-as-pure": "^7.15.4",
+				"@babel/helper-wrap-function": "^7.15.4",
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
-			"integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+			"integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.15.0",
-				"@babel/helper-optimise-call-expression": "^7.14.5",
-				"@babel/traverse": "^7.15.0",
-				"@babel/types": "^7.15.0"
+				"@babel/helper-member-expression-to-functions": "^7.15.4",
+				"@babel/helper-optimise-call-expression": "^7.15.4",
+				"@babel/traverse": "^7.15.4",
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.14.8",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
-			"integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+			"integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
 			"requires": {
-				"@babel/types": "^7.14.8"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-skip-transparent-expression-wrappers": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.14.5.tgz",
-			"integrity": "sha512-dmqZB7mrb94PZSAOYtr+ZN5qt5owZIAgqtoTuqiFbHFtxgEcmQlRJVI+bO++fciBunXtB6MK7HrzrfcAzIz2NQ==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.15.4.tgz",
+			"integrity": "sha512-BMRLsdh+D1/aap19TycS4eD1qELGrCBJwzaY9IE8LrpJtJb+H7rQkPIdsfgnMtLBA6DJls7X9z93Z4U8h7xw0A==",
 			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-			"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+			"integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
 			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-validator-identifier": {
@@ -296,24 +296,24 @@
 			"integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow=="
 		},
 		"@babel/helper-wrap-function": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.14.5.tgz",
-			"integrity": "sha512-YEdjTCq+LNuNS1WfxsDCNpgXkJaIyqco6DAelTUjT4f2KIWC1nBcaCaSdHTBqQVLnTBexBcVcFhLSU1KnYuePQ==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.15.4.tgz",
+			"integrity": "sha512-Y2o+H/hRV5W8QhIfTpRIBwl57y8PrZt6JM3V8FOo5qarjshHItyH5lXlpMfBfmBefOqSCpKZs/6Dxqp0E/U+uw==",
 			"requires": {
-				"@babel/helper-function-name": "^7.14.5",
-				"@babel/template": "^7.14.5",
-				"@babel/traverse": "^7.14.5",
-				"@babel/types": "^7.14.5"
+				"@babel/helper-function-name": "^7.15.4",
+				"@babel/template": "^7.15.4",
+				"@babel/traverse": "^7.15.4",
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.15.3",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.3.tgz",
-			"integrity": "sha512-HwJiz52XaS96lX+28Tnbu31VeFSQJGOeKHJeaEPQlTl7PnlhFElWPj8tUXtqFIzeN86XxXoBr+WFAyK2PPVz6g==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.4.tgz",
+			"integrity": "sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==",
 			"requires": {
-				"@babel/template": "^7.14.5",
-				"@babel/traverse": "^7.15.0",
-				"@babel/types": "^7.15.0"
+				"@babel/template": "^7.15.4",
+				"@babel/traverse": "^7.15.4",
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/highlight": {
@@ -357,11 +357,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -378,27 +373,27 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.15.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
-			"integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA=="
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.4.tgz",
+			"integrity": "sha512-xmzz+7fRpjrvDUj+GV7zfz/R3gSK2cOxGlazaXooxspCr539cbTXJKvBJzSVI2pPhcRGquoOtaIkKCsHQUiO3w=="
 		},
 		"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.14.5.tgz",
-			"integrity": "sha512-ZoJS2XCKPBfTmL122iP6NM9dOg+d4lc9fFk3zxc8iDjvt8Pk4+TlsHSKhIPf6X+L5ORCdBzqMZDjL/WHj7WknQ==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.15.4.tgz",
+			"integrity": "sha512-eBnpsl9tlhPhpI10kU06JHnrYXwg3+V6CaP2idsCXNef0aeslpqyITXQ74Vfk5uHgY7IG7XP0yIH8b42KSzHog==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.14.5",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.14.5",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.15.4",
 				"@babel/plugin-proposal-optional-chaining": "^7.14.5"
 			}
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.14.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.14.9.tgz",
-			"integrity": "sha512-d1lnh+ZnKrFKwtTYdw320+sQWCTwgkB9fmUhNXRADA4akR6wLjaruSGnIEUjpt9HCOwTr4ynFTKu19b7rFRpmw==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.15.4.tgz",
+			"integrity": "sha512-2zt2g5vTXpMC3OmK6uyjvdXptbhBXfA77XGrd3gh93zwG8lZYBLOBImiGBEG0RANu3JqKEACCz5CGk73OJROBw==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.14.5",
-				"@babel/helper-remap-async-to-generator": "^7.14.5",
+				"@babel/helper-remap-async-to-generator": "^7.15.4",
 				"@babel/plugin-syntax-async-generators": "^7.8.4"
 			}
 		},
@@ -412,11 +407,11 @@
 			}
 		},
 		"@babel/plugin-proposal-class-static-block": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.14.5.tgz",
-			"integrity": "sha512-KBAH5ksEnYHCegqseI5N9skTdxgJdmDoAOc0uXa+4QMYKeZD0w5IARh4FMlTNtaHhbB8v+KzMdTgxMMzsIy6Yg==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.15.4.tgz",
+			"integrity": "sha512-M682XWrrLNk3chXCjoPUQWOyYsB93B9z3mRyjtqqYJWDf2mfCdIYgDrA11cgNVhAQieaq6F2fn2f3wI0U4aTjA==",
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.14.5",
+				"@babel/helper-create-class-features-plugin": "^7.15.4",
 				"@babel/helper-plugin-utils": "^7.14.5",
 				"@babel/plugin-syntax-class-static-block": "^7.14.5"
 			}
@@ -526,12 +521,12 @@
 			}
 		},
 		"@babel/plugin-proposal-private-property-in-object": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.14.5.tgz",
-			"integrity": "sha512-62EyfyA3WA0mZiF2e2IV9mc9Ghwxcg8YTu8BS4Wss4Y3PY725OmS9M0qLORbJwLqFtGh+jiE4wAmocK2CTUK2Q==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.15.4.tgz",
+			"integrity": "sha512-X0UTixkLf0PCCffxgu5/1RQyGGbgZuKoI+vXP4iSbJSYwPb7hu06omsFGBvQ9lJEvwgrxHdS8B5nbfcd8GyUNA==",
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.14.5",
-				"@babel/helper-create-class-features-plugin": "^7.14.5",
+				"@babel/helper-annotate-as-pure": "^7.15.4",
+				"@babel/helper-create-class-features-plugin": "^7.15.4",
 				"@babel/helper-plugin-utils": "^7.14.5",
 				"@babel/plugin-syntax-private-property-in-object": "^7.14.5"
 			}
@@ -740,16 +735,16 @@
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.14.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.14.9.tgz",
-			"integrity": "sha512-NfZpTcxU3foGWbl4wxmZ35mTsYJy8oQocbeIMoDAGGFarAmSQlL+LWMkDx/tj6pNotpbX3rltIA4dprgAPOq5A==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.15.4.tgz",
+			"integrity": "sha512-Yjvhex8GzBmmPQUvpXRPWQ9WnxXgAFuZSrqOK/eJlOGIXwvv8H3UEdUigl1gb/bnjTrln+e8bkZUYCBt/xYlBg==",
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.14.5",
-				"@babel/helper-function-name": "^7.14.5",
-				"@babel/helper-optimise-call-expression": "^7.14.5",
+				"@babel/helper-annotate-as-pure": "^7.15.4",
+				"@babel/helper-function-name": "^7.15.4",
+				"@babel/helper-optimise-call-expression": "^7.15.4",
 				"@babel/helper-plugin-utils": "^7.14.5",
-				"@babel/helper-replace-supers": "^7.14.5",
-				"@babel/helper-split-export-declaration": "^7.14.5",
+				"@babel/helper-replace-supers": "^7.15.4",
+				"@babel/helper-split-export-declaration": "^7.15.4",
 				"globals": "^11.1.0"
 			}
 		},
@@ -805,9 +800,9 @@
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.14.5.tgz",
-			"integrity": "sha512-CfmqxSUZzBl0rSjpoQSFoR9UEj3HzbGuGNL21/iFTmjb5gFggJp3ph0xR1YBhexmLoKRHzgxuFvty2xdSt6gTA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.15.4.tgz",
+			"integrity": "sha512-DRTY9fA751AFBDh2oxydvVm4SYevs5ILTWLs6xKXps4Re/KG5nfUkr+TdHCrRWB8C69TlzVgA9b3RmGWmgN9LA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.14.5"
 			}
@@ -848,25 +843,25 @@
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.15.0.tgz",
-			"integrity": "sha512-3H/R9s8cXcOGE8kgMlmjYYC9nqr5ELiPkJn4q0mypBrjhYQoc+5/Maq69vV4xRPWnkzZuwJPf5rArxpB/35Cig==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.15.4.tgz",
+			"integrity": "sha512-qg4DPhwG8hKp4BbVDvX1s8cohM8a6Bvptu4l6Iingq5rW+yRUAhe/YRup/YcW2zCOlrysEWVhftIcKzrEZv3sA==",
 			"requires": {
-				"@babel/helper-module-transforms": "^7.15.0",
+				"@babel/helper-module-transforms": "^7.15.4",
 				"@babel/helper-plugin-utils": "^7.14.5",
-				"@babel/helper-simple-access": "^7.14.8",
+				"@babel/helper-simple-access": "^7.15.4",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.14.5.tgz",
-			"integrity": "sha512-mNMQdvBEE5DcMQaL5LbzXFMANrQjd2W7FPzg34Y4yEz7dBgdaC+9B84dSO+/1Wba98zoDbInctCDo4JGxz1VYA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.15.4.tgz",
+			"integrity": "sha512-fJUnlQrl/mezMneR72CKCgtOoahqGJNVKpompKwzv3BrEXdlPspTcyxrZ1XmDTIr9PpULrgEQo3qNKp6dW7ssw==",
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.14.5",
-				"@babel/helper-module-transforms": "^7.14.5",
+				"@babel/helper-hoist-variables": "^7.15.4",
+				"@babel/helper-module-transforms": "^7.15.4",
 				"@babel/helper-plugin-utils": "^7.14.5",
-				"@babel/helper-validator-identifier": "^7.14.5",
+				"@babel/helper-validator-identifier": "^7.14.9",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
 		},
@@ -905,9 +900,9 @@
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.14.5.tgz",
-			"integrity": "sha512-Tl7LWdr6HUxTmzQtzuU14SqbgrSKmaR77M0OKyq4njZLQTPfOvzblNKyNkGwOfEFCEx7KeYHQHDI0P3F02IVkA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.15.4.tgz",
+			"integrity": "sha512-9WB/GUTO6lvJU3XQsSr6J/WKvBC2hcs4Pew8YxZagi6GkTdniyqp8On5kqdK8MN0LMeu0mGbhPN+O049NV/9FQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.14.5"
 			}
@@ -1057,11 +1052,11 @@
 			}
 		},
 		"@babel/plugin-transform-typescript": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.15.0.tgz",
-			"integrity": "sha512-WIIEazmngMEEHDaPTx0IZY48SaAmjVWe3TRSX7cmJXn0bEv9midFzAjxiruOWYIVf5iQ10vFx7ASDpgEO08L5w==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.15.4.tgz",
+			"integrity": "sha512-sM1/FEjwYjXvMwu1PJStH11kJ154zd/lpY56NQJ5qH2D0mabMv1CAy/kdvS9RP4Xgfj9fBBA3JiSLdDHgXdzOA==",
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.15.0",
+				"@babel/helper-create-class-features-plugin": "^7.15.4",
 				"@babel/helper-plugin-utils": "^7.14.5",
 				"@babel/plugin-syntax-typescript": "^7.14.5"
 			}
@@ -1084,18 +1079,18 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.15.0.tgz",
-			"integrity": "sha512-FhEpCNFCcWW3iZLg0L2NPE9UerdtsCR6ZcsGHUX6Om6kbCQeL5QZDqFDmeNHC6/fy6UH3jEge7K4qG5uC9In0Q==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.15.4.tgz",
+			"integrity": "sha512-4f2nLw+q6ht8gl3sHCmNhmA5W6b1ItLzbH3UrKuJxACHr2eCpk96jwjrAfCAaXaaVwTQGnyUYHY2EWXJGt7TUQ==",
 			"requires": {
 				"@babel/compat-data": "^7.15.0",
-				"@babel/helper-compilation-targets": "^7.15.0",
+				"@babel/helper-compilation-targets": "^7.15.4",
 				"@babel/helper-plugin-utils": "^7.14.5",
 				"@babel/helper-validator-option": "^7.14.5",
-				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.14.5",
-				"@babel/plugin-proposal-async-generator-functions": "^7.14.9",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.15.4",
+				"@babel/plugin-proposal-async-generator-functions": "^7.15.4",
 				"@babel/plugin-proposal-class-properties": "^7.14.5",
-				"@babel/plugin-proposal-class-static-block": "^7.14.5",
+				"@babel/plugin-proposal-class-static-block": "^7.15.4",
 				"@babel/plugin-proposal-dynamic-import": "^7.14.5",
 				"@babel/plugin-proposal-export-namespace-from": "^7.14.5",
 				"@babel/plugin-proposal-json-strings": "^7.14.5",
@@ -1106,7 +1101,7 @@
 				"@babel/plugin-proposal-optional-catch-binding": "^7.14.5",
 				"@babel/plugin-proposal-optional-chaining": "^7.14.5",
 				"@babel/plugin-proposal-private-methods": "^7.14.5",
-				"@babel/plugin-proposal-private-property-in-object": "^7.14.5",
+				"@babel/plugin-proposal-private-property-in-object": "^7.15.4",
 				"@babel/plugin-proposal-unicode-property-regex": "^7.14.5",
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
 				"@babel/plugin-syntax-class-properties": "^7.12.13",
@@ -1125,25 +1120,25 @@
 				"@babel/plugin-transform-arrow-functions": "^7.14.5",
 				"@babel/plugin-transform-async-to-generator": "^7.14.5",
 				"@babel/plugin-transform-block-scoped-functions": "^7.14.5",
-				"@babel/plugin-transform-block-scoping": "^7.14.5",
-				"@babel/plugin-transform-classes": "^7.14.9",
+				"@babel/plugin-transform-block-scoping": "^7.15.3",
+				"@babel/plugin-transform-classes": "^7.15.4",
 				"@babel/plugin-transform-computed-properties": "^7.14.5",
 				"@babel/plugin-transform-destructuring": "^7.14.7",
 				"@babel/plugin-transform-dotall-regex": "^7.14.5",
 				"@babel/plugin-transform-duplicate-keys": "^7.14.5",
 				"@babel/plugin-transform-exponentiation-operator": "^7.14.5",
-				"@babel/plugin-transform-for-of": "^7.14.5",
+				"@babel/plugin-transform-for-of": "^7.15.4",
 				"@babel/plugin-transform-function-name": "^7.14.5",
 				"@babel/plugin-transform-literals": "^7.14.5",
 				"@babel/plugin-transform-member-expression-literals": "^7.14.5",
 				"@babel/plugin-transform-modules-amd": "^7.14.5",
-				"@babel/plugin-transform-modules-commonjs": "^7.15.0",
-				"@babel/plugin-transform-modules-systemjs": "^7.14.5",
+				"@babel/plugin-transform-modules-commonjs": "^7.15.4",
+				"@babel/plugin-transform-modules-systemjs": "^7.15.4",
 				"@babel/plugin-transform-modules-umd": "^7.14.5",
 				"@babel/plugin-transform-named-capturing-groups-regex": "^7.14.9",
 				"@babel/plugin-transform-new-target": "^7.14.5",
 				"@babel/plugin-transform-object-super": "^7.14.5",
-				"@babel/plugin-transform-parameters": "^7.14.5",
+				"@babel/plugin-transform-parameters": "^7.15.4",
 				"@babel/plugin-transform-property-literals": "^7.14.5",
 				"@babel/plugin-transform-regenerator": "^7.14.5",
 				"@babel/plugin-transform-reserved-words": "^7.14.5",
@@ -1155,7 +1150,7 @@
 				"@babel/plugin-transform-unicode-escapes": "^7.14.5",
 				"@babel/plugin-transform-unicode-regex": "^7.14.5",
 				"@babel/preset-modules": "^0.1.4",
-				"@babel/types": "^7.15.0",
+				"@babel/types": "^7.15.4",
 				"babel-plugin-polyfill-corejs2": "^0.2.2",
 				"babel-plugin-polyfill-corejs3": "^0.2.2",
 				"babel-plugin-polyfill-regenerator": "^0.2.2",
@@ -1205,52 +1200,52 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.15.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
-			"integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+			"integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"@babel/runtime-corejs3": {
-			"version": "7.15.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.15.3.tgz",
-			"integrity": "sha512-30A3lP+sRL6ml8uhoJSs+8jwpKzbw8CqBvDc1laeptxPm5FahumJxirigcbD2qTs71Sonvj1cyZB0OKGAmxQ+A==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.15.4.tgz",
+			"integrity": "sha512-lWcAqKeB624/twtTc3w6w/2o9RqJPaNBhPGK6DKLSiwuVWC7WFkypWyNg+CpZoyJH0jVzv1uMtXZ/5/lQOLtCg==",
 			"requires": {
 				"core-js-pure": "^3.16.0",
 				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"@babel/template": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-			"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+			"integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
 			"requires": {
 				"@babel/code-frame": "^7.14.5",
-				"@babel/parser": "^7.14.5",
-				"@babel/types": "^7.14.5"
+				"@babel/parser": "^7.15.4",
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
-			"integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+			"integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
 			"requires": {
 				"@babel/code-frame": "^7.14.5",
-				"@babel/generator": "^7.15.0",
-				"@babel/helper-function-name": "^7.14.5",
-				"@babel/helper-hoist-variables": "^7.14.5",
-				"@babel/helper-split-export-declaration": "^7.14.5",
-				"@babel/parser": "^7.15.0",
-				"@babel/types": "^7.15.0",
+				"@babel/generator": "^7.15.4",
+				"@babel/helper-function-name": "^7.15.4",
+				"@babel/helper-hoist-variables": "^7.15.4",
+				"@babel/helper-split-export-declaration": "^7.15.4",
+				"@babel/parser": "^7.15.4",
+				"@babel/types": "^7.15.4",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/types": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-			"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.4.tgz",
+			"integrity": "sha512-0f1HJFuGmmbrKTCZtbm3cU+b/AqdEYk5toj5iQur58xkVMlS0JWaKxTBSmCXd47uiN7vbcozAupm6Mvs80GNhw==",
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.14.9",
 				"to-fast-properties": "^2.0.0"
@@ -2159,6 +2154,21 @@
 				"buffer": "^6.0.3"
 			}
 		},
+		"@testing-library/dom": {
+			"version": "7.31.2",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
+			"integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/runtime": "^7.12.5",
+				"@types/aria-query": "^4.2.0",
+				"aria-query": "^4.2.2",
+				"chalk": "^4.1.0",
+				"dom-accessibility-api": "^0.5.6",
+				"lz-string": "^1.4.4",
+				"pretty-format": "^26.6.2"
+			}
+		},
 		"@testing-library/jest-dom": {
 			"version": "5.14.1",
 			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.14.1.tgz",
@@ -2193,54 +2203,6 @@
 			"requires": {
 				"@babel/runtime": "^7.12.5",
 				"@testing-library/dom": "^7.28.1"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "26.6.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-					"integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@testing-library/dom": {
-					"version": "7.31.2",
-					"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
-					"integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
-					"requires": {
-						"@babel/code-frame": "^7.10.4",
-						"@babel/runtime": "^7.12.5",
-						"@types/aria-query": "^4.2.0",
-						"aria-query": "^4.2.2",
-						"chalk": "^4.1.0",
-						"dom-accessibility-api": "^0.5.6",
-						"lz-string": "^1.4.4",
-						"pretty-format": "^26.6.2"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.14",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
-					"integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"pretty-format": {
-					"version": "26.6.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-					"integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
-					"requires": {
-						"@jest/types": "^26.6.2",
-						"ansi-regex": "^5.0.0",
-						"ansi-styles": "^4.0.0",
-						"react-is": "^17.0.1"
-					}
-				}
 			}
 		},
 		"@testing-library/user-event": {
@@ -2389,39 +2351,6 @@
 			"requires": {
 				"jest-diff": "^26.0.0",
 				"pretty-format": "^26.0.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "26.6.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-					"integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.14",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
-					"integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"pretty-format": {
-					"version": "26.6.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-					"integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
-					"requires": {
-						"@jest/types": "^26.6.2",
-						"ansi-regex": "^5.0.0",
-						"ansi-styles": "^4.0.0",
-						"react-is": "^17.0.1"
-					}
-				}
 			}
 		},
 		"@types/json-schema": {
@@ -2462,9 +2391,9 @@
 			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
 		},
 		"@types/node": {
-			"version": "12.20.21",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.21.tgz",
-			"integrity": "sha512-Qk7rOvV2A4vNgXNS88vEvbJE1NDFPCQ8AU+pNElrU2bA4yrRDef3fg3SUe+xkwyin3Bpg/Xh5JkNWTlsOcS2tA=="
+			"version": "12.20.23",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.23.tgz",
+			"integrity": "sha512-FW0q7NI8UnjbKrJK8NGr6QXY69ATw9IFe6ItIo5yozPwA9DU/xkhiPddctUVyrmFXvyFYerYgQak/qu200UBDw=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.1",
@@ -2608,69 +2537,17 @@
 				"regexpp": "^3.1.0",
 				"semver": "^7.3.5",
 				"tsutils": "^3.21.0"
-			},
-			"dependencies": {
-				"@typescript-eslint/experimental-utils": {
-					"version": "4.30.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.30.0.tgz",
-					"integrity": "sha512-K8RNIX9GnBsv5v4TjtwkKtqMSzYpjqAQg/oSphtxf3xxdt6T0owqnpojztjjTcatSteH3hLj3t/kklKx87NPqw==",
-					"requires": {
-						"@types/json-schema": "^7.0.7",
-						"@typescript-eslint/scope-manager": "4.30.0",
-						"@typescript-eslint/types": "4.30.0",
-						"@typescript-eslint/typescript-estree": "4.30.0",
-						"eslint-scope": "^5.1.1",
-						"eslint-utils": "^3.0.0"
-					}
-				},
-				"@typescript-eslint/scope-manager": {
-					"version": "4.30.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.30.0.tgz",
-					"integrity": "sha512-VJ/jAXovxNh7rIXCQbYhkyV2Y3Ac/0cVHP/FruTJSAUUm4Oacmn/nkN5zfWmWFEanN4ggP0vJSHOeajtHq3f8A==",
-					"requires": {
-						"@typescript-eslint/types": "4.30.0",
-						"@typescript-eslint/visitor-keys": "4.30.0"
-					}
-				},
-				"@typescript-eslint/types": {
-					"version": "4.30.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.30.0.tgz",
-					"integrity": "sha512-YKldqbNU9K4WpTNwBqtAerQKLLW/X2A/j4yw92e3ZJYLx+BpKLeheyzoPfzIXHfM8BXfoleTdiYwpsvVPvHrDw=="
-				},
-				"@typescript-eslint/typescript-estree": {
-					"version": "4.30.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.30.0.tgz",
-					"integrity": "sha512-6WN7UFYvykr/U0Qgy4kz48iGPWILvYL34xXJxvDQeiRE018B7POspNRVtAZscWntEPZpFCx4hcz/XBT+erenfg==",
-					"requires": {
-						"@typescript-eslint/types": "4.30.0",
-						"@typescript-eslint/visitor-keys": "4.30.0",
-						"debug": "^4.3.1",
-						"globby": "^11.0.3",
-						"is-glob": "^4.0.1",
-						"semver": "^7.3.5",
-						"tsutils": "^3.21.0"
-					}
-				},
-				"@typescript-eslint/visitor-keys": {
-					"version": "4.30.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.30.0.tgz",
-					"integrity": "sha512-pNaaxDt/Ol/+JZwzP7MqWc8PJQTUhZwoee/PVlQ+iYoYhagccvoHnC9e4l+C/krQYYkENxznhVSDwClIbZVxRw==",
-					"requires": {
-						"@typescript-eslint/types": "4.30.0",
-						"eslint-visitor-keys": "^2.0.0"
-					}
-				}
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "4.29.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.3.tgz",
-			"integrity": "sha512-ffIvbytTVWz+3keg+Sy94FG1QeOvmV9dP2YSdLFHw/ieLXWCa3U1TYu8IRCOpMv2/SPS8XqhM1+ou1YHsdzKrg==",
+			"version": "4.30.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.30.0.tgz",
+			"integrity": "sha512-K8RNIX9GnBsv5v4TjtwkKtqMSzYpjqAQg/oSphtxf3xxdt6T0owqnpojztjjTcatSteH3hLj3t/kklKx87NPqw==",
 			"requires": {
 				"@types/json-schema": "^7.0.7",
-				"@typescript-eslint/scope-manager": "4.29.3",
-				"@typescript-eslint/types": "4.29.3",
-				"@typescript-eslint/typescript-estree": "4.29.3",
+				"@typescript-eslint/scope-manager": "4.30.0",
+				"@typescript-eslint/types": "4.30.0",
+				"@typescript-eslint/typescript-estree": "4.30.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			}
@@ -2684,68 +2561,29 @@
 				"@typescript-eslint/types": "4.30.0",
 				"@typescript-eslint/typescript-estree": "4.30.0",
 				"debug": "^4.3.1"
-			},
-			"dependencies": {
-				"@typescript-eslint/scope-manager": {
-					"version": "4.30.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.30.0.tgz",
-					"integrity": "sha512-VJ/jAXovxNh7rIXCQbYhkyV2Y3Ac/0cVHP/FruTJSAUUm4Oacmn/nkN5zfWmWFEanN4ggP0vJSHOeajtHq3f8A==",
-					"requires": {
-						"@typescript-eslint/types": "4.30.0",
-						"@typescript-eslint/visitor-keys": "4.30.0"
-					}
-				},
-				"@typescript-eslint/types": {
-					"version": "4.30.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.30.0.tgz",
-					"integrity": "sha512-YKldqbNU9K4WpTNwBqtAerQKLLW/X2A/j4yw92e3ZJYLx+BpKLeheyzoPfzIXHfM8BXfoleTdiYwpsvVPvHrDw=="
-				},
-				"@typescript-eslint/typescript-estree": {
-					"version": "4.30.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.30.0.tgz",
-					"integrity": "sha512-6WN7UFYvykr/U0Qgy4kz48iGPWILvYL34xXJxvDQeiRE018B7POspNRVtAZscWntEPZpFCx4hcz/XBT+erenfg==",
-					"requires": {
-						"@typescript-eslint/types": "4.30.0",
-						"@typescript-eslint/visitor-keys": "4.30.0",
-						"debug": "^4.3.1",
-						"globby": "^11.0.3",
-						"is-glob": "^4.0.1",
-						"semver": "^7.3.5",
-						"tsutils": "^3.21.0"
-					}
-				},
-				"@typescript-eslint/visitor-keys": {
-					"version": "4.30.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.30.0.tgz",
-					"integrity": "sha512-pNaaxDt/Ol/+JZwzP7MqWc8PJQTUhZwoee/PVlQ+iYoYhagccvoHnC9e4l+C/krQYYkENxznhVSDwClIbZVxRw==",
-					"requires": {
-						"@typescript-eslint/types": "4.30.0",
-						"eslint-visitor-keys": "^2.0.0"
-					}
-				}
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "4.29.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.3.tgz",
-			"integrity": "sha512-x+w8BLXO7iWPkG5mEy9bA1iFRnk36p/goVlYobVWHyDw69YmaH9q6eA+Fgl7kYHmFvWlebUTUfhtIg4zbbl8PA==",
+			"version": "4.30.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.30.0.tgz",
+			"integrity": "sha512-VJ/jAXovxNh7rIXCQbYhkyV2Y3Ac/0cVHP/FruTJSAUUm4Oacmn/nkN5zfWmWFEanN4ggP0vJSHOeajtHq3f8A==",
 			"requires": {
-				"@typescript-eslint/types": "4.29.3",
-				"@typescript-eslint/visitor-keys": "4.29.3"
+				"@typescript-eslint/types": "4.30.0",
+				"@typescript-eslint/visitor-keys": "4.30.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "4.29.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.3.tgz",
-			"integrity": "sha512-s1eV1lKNgoIYLAl1JUba8NhULmf+jOmmeFO1G5MN/RBCyyzg4TIOfIOICVNC06lor+Xmy4FypIIhFiJXOknhIg=="
+			"version": "4.30.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.30.0.tgz",
+			"integrity": "sha512-YKldqbNU9K4WpTNwBqtAerQKLLW/X2A/j4yw92e3ZJYLx+BpKLeheyzoPfzIXHfM8BXfoleTdiYwpsvVPvHrDw=="
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "4.29.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.3.tgz",
-			"integrity": "sha512-45oQJA0bxna4O5TMwz55/TpgjX1YrAPOI/rb6kPgmdnemRZx/dB0rsx+Ku8jpDvqTxcE1C/qEbVHbS3h0hflag==",
+			"version": "4.30.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.30.0.tgz",
+			"integrity": "sha512-6WN7UFYvykr/U0Qgy4kz48iGPWILvYL34xXJxvDQeiRE018B7POspNRVtAZscWntEPZpFCx4hcz/XBT+erenfg==",
 			"requires": {
-				"@typescript-eslint/types": "4.29.3",
-				"@typescript-eslint/visitor-keys": "4.29.3",
+				"@typescript-eslint/types": "4.30.0",
+				"@typescript-eslint/visitor-keys": "4.30.0",
 				"debug": "^4.3.1",
 				"globby": "^11.0.3",
 				"is-glob": "^4.0.1",
@@ -2754,11 +2592,11 @@
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "4.29.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.3.tgz",
-			"integrity": "sha512-MGGfJvXT4asUTeVs0Q2m+sY63UsfnA+C/FDgBKV3itLBmM9H0u+URcneePtkd0at1YELmZK6HSolCqM4Fzs6yA==",
+			"version": "4.30.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.30.0.tgz",
+			"integrity": "sha512-pNaaxDt/Ol/+JZwzP7MqWc8PJQTUhZwoee/PVlQ+iYoYhagccvoHnC9e4l+C/krQYYkENxznhVSDwClIbZVxRw==",
 			"requires": {
-				"@typescript-eslint/types": "4.29.3",
+				"@typescript-eslint/types": "4.30.0",
 				"eslint-visitor-keys": "^2.0.0"
 			}
 		},
@@ -3337,11 +3175,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -4431,11 +4264,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -4738,14 +4566,14 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
 		"core-js": {
-			"version": "3.16.4",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.4.tgz",
-			"integrity": "sha512-Tq4GVE6XCjE+hcyW6hPy0ofN3hwtLudz5ZRdrlCnsnD/xkm/PWQRudzYHiKgZKUcefV6Q57fhDHjZHJP5dpfSg=="
+			"version": "3.17.2",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.2.tgz",
+			"integrity": "sha512-XkbXqhcXeMHPRk2ItS+zQYliAMilea2euoMsnpRRdDad6b2VY6CQQcwz1K8AnWesfw4p165RzY0bTnr3UrbYiA=="
 		},
 		"core-js-compat": {
-			"version": "3.16.4",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.4.tgz",
-			"integrity": "sha512-IzCSomxRdahCYb6G3HiN6pl3JCiM0NMunRcNa1pIeC7g17Vd6Ue3AT9anQiENPIm/svThUVer1pIbLMDERIsFw==",
+			"version": "3.17.2",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.17.2.tgz",
+			"integrity": "sha512-lHnt7A1Oqplebl5i0MrQyFv/yyEzr9p29OjlkcsFRDDgHwwQyVckfRGJ790qzXhkwM8ba4SFHHa2sO+T5f1zGg==",
 			"requires": {
 				"browserslist": "^4.16.8",
 				"semver": "7.0.0"
@@ -4759,14 +4587,14 @@
 			}
 		},
 		"core-js-pure": {
-			"version": "3.16.3",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.16.3.tgz",
-			"integrity": "sha512-6In+2RwN0FT5yK0ZnhDP5rco/NnuuFZhHauQizZiHo5lDnqAvq8Phxcpy3f+prJOqtKodt/cftBl/GTOW0kiqQ=="
+			"version": "3.17.2",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.17.2.tgz",
+			"integrity": "sha512-2VV7DlIbooyTI7Bh+yzOOWL9tGwLnQKHno7qATE+fqZzDKYr6llVjVQOzpD/QLZFgXDPb8T71pJokHEZHEYJhQ=="
 		},
 		"core-util-is": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
 		},
 		"cosmiconfig": {
 			"version": "7.0.1",
@@ -4913,11 +4741,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -4998,11 +4821,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -5082,11 +4900,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
 					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -5183,11 +4996,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -5261,11 +5069,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -5406,11 +5209,6 @@
 						"parse-json": "^4.0.0"
 					}
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -5537,11 +5335,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -5625,11 +5418,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -6215,9 +6003,9 @@
 			"integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.818",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.818.tgz",
-			"integrity": "sha512-c/Z9gIr+jDZAR9q+mn40hEc1NharBT+8ejkarjbCDnBNFviI6hvcC5j2ezkAXru//bTnQp5n6iPi0JA83Tla1Q=="
+			"version": "1.3.830",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.830.tgz",
+			"integrity": "sha512-gBN7wNAxV5vl1430dG+XRcQhD4pIeYeak6p6rjdCtlz5wWNwDad8jwvphe5oi1chL5MV6RNRikfffBBiFuj+rQ=="
 		},
 		"elliptic": {
 			"version": "6.5.4",
@@ -6427,9 +6215,9 @@
 			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
 		},
 		"escape-string-regexp": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
 			"version": "2.0.0",
@@ -6682,9 +6470,9 @@
 			}
 		},
 		"eslint-plugin-flowtype": {
-			"version": "5.9.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-5.9.1.tgz",
-			"integrity": "sha512-ncUBL9lbhrcOlM5p6xQJT2c0z9co/FlP0mXdva6FrkvtzOoN7wdc8ioASonEpcWffOxnJPFPI8N0sHCavE6NAg==",
+			"version": "5.9.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-5.9.2.tgz",
+			"integrity": "sha512-qxE/eo9DCN7800MIB/O1ToOiFuOPOlaMJWQY2BEm69oY7RCm3s2X1z4CdgtFvDDWf9RSSugZm1KRhdBMBueKbg==",
 			"requires": {
 				"lodash": "^4.17.15",
 				"string-natural-compare": "^3.0.1"
@@ -7564,9 +7352,9 @@
 			}
 		},
 		"follow-redirects": {
-			"version": "1.14.2",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.2.tgz",
-			"integrity": "sha512-yLR6WaE2lbF0x4K2qE2p9PEXKLDjUjnR/xmjS3wHAYxtlsI9MLLBJUZirAHKzUZDGLxje7w/cXR49WOUo4rbsA=="
+			"version": "1.14.3",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
+			"integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw=="
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -7644,11 +7432,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"fill-range": {
 					"version": "4.0.0",
@@ -8560,11 +8343,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -9329,39 +9107,6 @@
 				"diff-sequences": "^26.6.2",
 				"jest-get-type": "^26.3.0",
 				"pretty-format": "^26.6.2"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "26.6.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-					"integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.14",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
-					"integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"pretty-format": {
-					"version": "26.6.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-					"integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
-					"requires": {
-						"@jest/types": "^26.6.2",
-						"ansi-regex": "^5.0.0",
-						"ansi-styles": "^4.0.0",
-						"react-is": "^17.0.1"
-					}
-				}
 			}
 		},
 		"jest-docblock": {
@@ -11486,7 +11231,6 @@
 			"version": "8.3.6",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
 			"integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
-			"dev": true,
 			"requires": {
 				"colorette": "^1.2.2",
 				"nanoid": "^3.1.23",
@@ -11542,11 +11286,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -11621,11 +11360,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -11703,11 +11437,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -11782,11 +11511,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -11864,11 +11588,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -11943,11 +11662,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -12025,11 +11739,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -12104,11 +11813,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -12187,11 +11891,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -12273,11 +11972,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -12357,11 +12051,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -12436,11 +12125,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -12521,11 +12205,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
 					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -12617,11 +12296,6 @@
 					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
 					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -12706,11 +12380,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -12784,11 +12453,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -12864,11 +12528,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -12942,11 +12601,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -13023,11 +12677,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -13103,11 +12752,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -13181,11 +12825,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -13261,11 +12900,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -13339,11 +12973,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -13419,11 +13048,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -13494,12 +13118,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 					"dev": true
 				},
 				"has-flag": {
@@ -13585,11 +13203,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -13665,11 +13278,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -13743,11 +13351,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -13830,12 +13433,6 @@
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 					"dev": true
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-					"dev": true
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -13914,11 +13511,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -14042,11 +13634,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -14149,11 +13736,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -14227,11 +13809,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -14309,11 +13886,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -14398,11 +13970,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -14489,11 +14056,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -14575,11 +14137,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -14665,11 +14222,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -14751,11 +14303,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -14841,11 +14388,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -14923,11 +14465,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -15003,11 +14540,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -15082,11 +14614,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -15169,12 +14696,6 @@
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 					"dev": true
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-					"dev": true
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -15251,11 +14772,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -15335,11 +14851,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -15413,11 +14924,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -15494,11 +15000,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -15582,11 +15083,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -15669,11 +15165,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -15754,11 +15245,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -15841,11 +15327,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -15926,11 +15407,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -16013,11 +15489,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -16104,11 +15575,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -16190,11 +15656,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -16274,11 +15735,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -16352,11 +15808,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -16432,11 +15883,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -16548,11 +15994,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -16632,11 +16073,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
 					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -16725,11 +16161,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -16806,11 +16237,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -16891,11 +16317,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -16927,18 +16348,6 @@
 			"integrity": "sha512-jDUfCPJbKOABhwpUKcqCVbbXiloe/QXMcbJ6Iipf3sDIihEzTqRCeMBfRaOHxhBuTYqtASrI1KJWxzztZU4qUQ==",
 			"requires": {
 				"postcss": "^8.1.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "8.3.6",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
-					"integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
-					"requires": {
-						"colorette": "^1.2.2",
-						"nanoid": "^3.1.23",
-						"source-map-js": "^0.6.2"
-					}
-				}
 			}
 		},
 		"postcss-selector-matches": {
@@ -16990,11 +16399,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -17070,11 +16474,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -17161,11 +16560,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -17246,11 +16640,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -17688,6 +17077,11 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+				},
+				"escape-string-regexp": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
 				},
 				"globby": {
 					"version": "11.0.1",
@@ -18301,11 +17695,6 @@
 					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
 					"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -18554,13 +17943,6 @@
 			"integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
 			"requires": {
 				"tslib": "^1.9.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "1.14.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-				}
 			}
 		},
 		"safe-buffer": {
@@ -19326,6 +18708,13 @@
 			"integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
 			"requires": {
 				"escape-string-regexp": "^2.0.0"
+			},
+			"dependencies": {
+				"escape-string-regexp": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+				}
 			}
 		},
 		"stackframe": {
@@ -19642,11 +19031,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -19755,11 +19139,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -19812,9 +19191,9 @@
 			}
 		},
 		"tailwindcss": {
-			"version": "npm:@tailwindcss/postcss7-compat@2.2.8",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/postcss7-compat/-/postcss7-compat-2.2.8.tgz",
-			"integrity": "sha512-U4hjDuAenz2068Y/Hz+b9Z4mawBXisjBN5lSJ+kFBJ8gPjeW3o7qtug0iy+ndu9o7d9UHzYcbzgcw6ymfOv++w==",
+			"version": "npm:@tailwindcss/postcss7-compat@2.2.9",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/postcss7-compat/-/postcss7-compat-2.2.9.tgz",
+			"integrity": "sha512-cE0ed0whqMPPih/mgo205e/Fdl/N9ZC8Z/0OyUBGWuvgNjNhsrT/avpuoYECI58FDTMT2tm5kKGJsJsl+sqh7A==",
 			"dev": true,
 			"requires": {
 				"arg": "^5.0.1",
@@ -19823,7 +19202,7 @@
 				"chalk": "^4.1.2",
 				"chokidar": "^3.5.2",
 				"color": "^4.0.1",
-				"cosmiconfig": "^7.0.0",
+				"cosmiconfig": "^7.0.1",
 				"detective": "^5.2.0",
 				"didyoumean": "^1.2.2",
 				"dlv": "^1.1.3",
@@ -19887,12 +19266,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 					"dev": true
 				},
 				"fs-extra": {
@@ -20107,9 +19480,9 @@
 					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
 				},
 				"find-cache-dir": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-					"integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+					"version": "3.3.2",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+					"integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
 					"requires": {
 						"commondir": "^1.0.1",
 						"make-dir": "^3.0.2",

--- a/src/components/DisconnectWallet.tsx
+++ b/src/components/DisconnectWallet.tsx
@@ -11,6 +11,7 @@ interface ButtonProps {
   setTezos: Dispatch<SetStateAction<TezosToolkit>>;
   setBeaconConnection: Dispatch<SetStateAction<boolean>>;
 }
+
 function DisconnectButton({
   wallet,
   setPublicToken,

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -2,7 +2,7 @@ import { TezosToolkit } from "@taquito/taquito";
 import React, { useEffect, useState } from "react";
 import Button from "./Button";
 import ConnectButton from "./ConnectWallet";
-import { getHoundRenderer } from "./scripts/generate-hounds";
+import { getRandomHoundRenderer } from "../scripts/generate-hounds";
 import "./css/Home.css";
 import { SVGSlantTop, SVGSlantBottom } from "./svgs";
 
@@ -79,7 +79,7 @@ function HoundPlay() {
         const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
         ctx.imageSmoothingEnabled = false;
 
-        const renderHound = await getHoundRenderer();
+        const renderHound = await getRandomHoundRenderer();
         setRenderer(() => () => renderHound(ctx, canvasBounds.width, canvasBounds.height));
         renderHound(ctx, canvasBounds.width, canvasBounds.height);
       } catch (e) {

--- a/src/scripts/generate-hounds.test.ts
+++ b/src/scripts/generate-hounds.test.ts
@@ -1,0 +1,9 @@
+import { genomeNumberToImageIndex } from "./generate-hounds";
+import { decodeBase62Quadlet } from "./hound-genome";
+
+describe("Map quadlet to asset index", () => {
+  it("can map quadlet values to indices correctly", () => {
+    const maxQuadlet = decodeBase62Quadlet("ZZZZ");
+    expect(genomeNumberToImageIndex(maxQuadlet / 5)).toBe(1);
+  });
+});

--- a/src/scripts/generate-hounds.test.ts
+++ b/src/scripts/generate-hounds.test.ts
@@ -6,4 +6,8 @@ describe("Map quadlet to asset index", () => {
     const maxQuadlet = decodeBase62Quadlet("ZZZZ");
     expect(genomeNumberToImageIndex(maxQuadlet / 5)).toBe(1);
   });
+
+  it("rejects bad numbers", () => {
+    expect(() => genomeNumberToImageIndex(decodeBase62Quadlet("ZZZZ") + 10)).toThrow();
+  });
 });

--- a/src/scripts/generate-hounds.ts
+++ b/src/scripts/generate-hounds.ts
@@ -91,10 +91,10 @@ export async function getRandomHoundRenderer(): Promise<CanvasRenderFunc> {
 const MaxQuadLetValue = decodeBase62Quadlet("ZZZZ");
 export function genomeNumberToImageIndex(base10Quadlet: number): number {
   assert(base10Quadlet >= 0 && base10Quadlet <= MaxQuadLetValue);
-  for (let i = 0; i < MaxQuadLetValue; ++i) {
+  for (let i = 0; i < MaxTextureCount; ++i) {
     if (
-      base10Quadlet >= (i / 5) * MaxQuadLetValue &&
-      base10Quadlet < ((i + 1) / 5) * MaxQuadLetValue
+      base10Quadlet >= (i / MaxTextureCount) * MaxQuadLetValue &&
+      base10Quadlet < ((i + 1) / MaxTextureCount) * MaxQuadLetValue
     ) {
       return i;
     }

--- a/src/scripts/hound-genome.test.ts
+++ b/src/scripts/hound-genome.test.ts
@@ -1,0 +1,31 @@
+import { AssertionError } from "assert";
+import { decodeBase62Quadlet, decodeGenome } from "./hound-genome";
+
+describe("Base62 Quadlet decoder", () => {
+  it("Can decode base62 quadlets", () => {
+    expect(decodeBase62Quadlet("ZZZZ")).toBe(14776335);
+    expect(decodeBase62Quadlet("zzzz")).toBe(8478225);
+    expect(decodeBase62Quadlet("aaaa")).toBe(2422350);
+    expect(decodeBase62Quadlet("1234")).toBe(246206);
+    expect(decodeBase62Quadlet("12aB")).toBe(246673);
+  });
+
+  it("Does not allow decoding strings that aren't quadlets", () => {
+    expect(() => decodeBase62Quadlet("ZZZZZ")).toThrow(AssertionError);
+    expect(() => decodeBase62Quadlet("12")).toThrow(AssertionError);
+  });
+});
+
+describe("Genome decoder", () => {
+  it("Does not allow genomes of incorrect size", () => {
+    expect(() => decodeGenome("xx")).toThrow(AssertionError);
+  });
+
+  it("Decodes the genomes correctly", () => {
+    const sample = decodeGenome("zzzz".repeat(10));
+    expect(sample.base).toBe(8478225);
+    expect(sample.mouth).toBe(8478225);
+    expect(sample.eyes).toBe(8478225);
+    expect(sample.horn).toBe(8478225);
+  });
+});

--- a/src/scripts/hound-genome.ts
+++ b/src/scripts/hound-genome.ts
@@ -1,0 +1,54 @@
+import { assert } from "../util/assert";
+
+// maps a Hound's feature to it's corresponding number in the Genome.
+// eg: mouth -> 1202
+export type HoundGenomeData = {
+  mouth: number;
+  horn: number;
+  base: number;
+  eyes: number;
+};
+
+export function decodeBase62Quadlet(quadlet: string): number {
+  assert(quadlet.length == 4, "expected a string of length 4");
+
+  const isUpper = (code: number) => code >= 65 && code <= 90;
+  const isLower = (code: number) => code >= 97 && code <= 122;
+  const isDigit = (code: number) => code >= 48 && code <= 57;
+
+  const base62ToBase10 = (code: number) => {
+    if (isLower(code)) return 10 + (code - 97);
+    if (isUpper(code)) return 36 + (code - 65);
+    assert(isDigit(code));
+    return code - 48;
+  };
+
+  let ret = 0;
+  let pow = quadlet.length - 1;
+  for (let i = 0; i < quadlet.length; ++i) {
+    const ascii = quadlet.charCodeAt(i);
+    ret += base62ToBase10(ascii) * Math.pow(62, pow);
+    --pow;
+  }
+
+  return ret;
+}
+
+export function decodeGenome(genome: string): HoundGenomeData {
+  assert(genome.length == 40, "Invalid hound DNA sequence (must be 40 characters)");
+  let quadlets = genome.match(/.{1,4}/g);
+  assert(quadlets && quadlets.length == 10);
+  quadlets = quadlets as RegExpMatchArray;
+
+  const base = decodeBase62Quadlet(quadlets[0]);
+  const eyes = decodeBase62Quadlet(quadlets[1]);
+  const mouth = decodeBase62Quadlet(quadlets[2]);
+  const horn = decodeBase62Quadlet(quadlets[3]);
+
+  return {
+    base,
+    eyes,
+    mouth,
+    horn,
+  };
+}

--- a/src/util/assert.ts
+++ b/src/util/assert.ts
@@ -1,6 +1,7 @@
 import { AssertionError } from "assert";
 
-export function assert(cond: any, message?: string) {
+// eslint-disable-next-line
+export function assert(cond: any, message?: string): any{
   if (!cond) throw new AssertionError({ message });
   return cond;
 }

--- a/src/util/assert.ts
+++ b/src/util/assert.ts
@@ -1,0 +1,6 @@
+import { AssertionError } from "assert";
+
+export function assert(cond: any, message?: string) {
+  if (!cond) throw new AssertionError({ message });
+  return cond;
+}


### PR DESCRIPTION
We can use the `npm test` command to run the jest test suite that has been set up with this PR.
Now we can decode a genome string and map it to images.

The tests assert that the logic is correct, but there is still no use for these features as we have yet to add gen-0 hounds.